### PR TITLE
Merge UI-hype-2 with dev

### DIFF
--- a/Actors/Enemies/TestEnemy/melee_test_enemy.gd
+++ b/Actors/Enemies/TestEnemy/melee_test_enemy.gd
@@ -2,6 +2,6 @@ extends BaseEnemyBehaviour
 class_name MeleeTestEnemy
 
 func _idle_logic() -> void:
-    velocity.x = 50
-    
-    move_and_slide()
+	velocity.x = 50
+	
+	move_and_slide()

--- a/Ammunition/Buckshot/buckshot.tscn
+++ b/Ammunition/Buckshot/buckshot.tscn
@@ -15,6 +15,7 @@ blast_force = 5.0
 _cooldown_timer = NodePath("CooldownTimer")
 
 [node name="CooldownTimer" type="Timer" parent="."]
+wait_time = 0.5
 one_shot = true
 
 [connection signal="timeout" from="CooldownTimer" to="." method="_cooldown_timeout"]

--- a/Ammunition/Slug/slug.tscn
+++ b/Ammunition/Slug/slug.tscn
@@ -7,7 +7,7 @@
 script = ExtResource("1_cxd1u")
 effective_range = Array[float]([100.0])
 damage = Array[float]([20.0, 40.0])
-max_ammo = 3
+max_ammo = 6
 _pellet = ExtResource("2_aokum")
 _pellet_count = 1
 _pellet_spread_angle = 1
@@ -15,6 +15,7 @@ blast_force = 4.0
 _cooldown_timer = NodePath("CooldownTimer")
 
 [node name="CooldownTimer" type="Timer" parent="."]
+wait_time = 0.5
 one_shot = true
 
 [connection signal="timeout" from="CooldownTimer" to="." method="_cooldown_timeout"]

--- a/Globals/scene_manager.gd
+++ b/Globals/scene_manager.gd
@@ -12,6 +12,8 @@ var scene_library := {
 
 var active_scene:Node # instance of the current scene
 
+var hype_meter : HypeMeter # Instance of the hype meter so that it can be accessed from anywhere
+
 func _ready():
 	active_scene = $"/root/MainMenu" # set the main menu as the active scene
 

--- a/Stages/Playground/playground.tscn
+++ b/Stages/Playground/playground.tscn
@@ -1,10 +1,11 @@
-[gd_scene load_steps=11 format=3 uid="uid://c32res81juhqg"]
+[gd_scene load_steps=12 format=3 uid="uid://c32res81juhqg"]
 
 [ext_resource type="PackedScene" uid="uid://7vyirkeofdrx" path="res://Actors/shared/HittableComponent.tscn" id="1_ms6ri"]
 [ext_resource type="PackedScene" uid="uid://d0m6asdiav5p7" path="res://Actors/Player/2DPlayer.tscn" id="1_qs7i5"]
 [ext_resource type="Script" path="res://Actors/Player/Scripts/camera_follow.gd" id="2_yljtj"]
 [ext_resource type="PackedScene" uid="uid://buyv076dqph8u" path="res://Actors/Enemies/TestEnemy/testenemy.tscn" id="4_qtr78"]
 [ext_resource type="Script" path="res://Stages/Shared/Scripts/Pause.gd" id="5_lblk1"]
+[ext_resource type="PackedScene" uid="uid://ydh7h6mcksme" path="res://UIs/Main/main_ui.tscn" id="6_ha557"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_np1uq"]
 size = Vector2(100, 100)
@@ -183,3 +184,6 @@ text = "Continue"
 [node name="Quit" type="Button" parent="Control/Center/VBox"]
 layout_mode = 2
 text = "Quit"
+
+[node name="MainUI" parent="." node_paths=PackedStringArray("player_hold") instance=ExtResource("6_ha557")]
+player_hold = NodePath("../2DPlayer")

--- a/UIs/Main/hype.gd
+++ b/UIs/Main/hype.gd
@@ -73,7 +73,7 @@ func _process(delta):
 # Increases the hype amount and increases the rank if it must
 # This funciton can be called globally using the scene manager
 # by typing `Scenemanager.hype_meter.increase_hype(amount)`
-func increase_hype(amount : float):
+func _increase_hype(amount : float):
 	hype += amount
 	while hype > 100:
 		hype -= 100
@@ -96,4 +96,4 @@ func increase_hype(amount : float):
 
 # Feel free to remove this, it's just a temporary thing until actual hype increases are implemented.
 func _on_temp_increase_hype_btn_pressed():
-	Scenemanager.hype_meter.increase_hype(25)
+	Scenemanager.hype_meter._increase_hype(25)

--- a/UIs/Main/hype.gd
+++ b/UIs/Main/hype.gd
@@ -1,0 +1,99 @@
+class_name HypeMeter extends Control
+
+# The current level of hype from 1-100
+var hype : float = 0
+# The current rank of the player from C-A as well as S and P
+var rank : String = "C"
+
+# Variables containing the node children for easy access
+@onready var rank_label : RichTextLabel = $VBoxContainer/HypeLabel
+@onready var hype_bar : ProgressBar = $VBoxContainer/HypeBar
+
+# Variables containing the time in seconds that each rank will take to fully drain
+# C is not included since it doesn't drain
+var P_drain : float = 2
+var S_drain : float = 4
+var A_drain : float = 5
+var B_drain : float = 6
+
+# Variables containing the amount that must be removed from the hype every second
+var P_time : float
+var S_time : float
+var A_time : float
+var B_time : float
+var C_time : float
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	P_time = 100/P_drain
+	S_time = 100/S_drain
+	A_time = 100/A_drain
+	B_time = 100/B_drain
+	C_time = 0
+	Scenemanager.hype_meter = self
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	match rank:
+		"P":
+			hype -= P_time*delta
+			if hype < 0:
+				hype = 100
+				rank = "S"
+		"S":
+			hype -= S_time*delta
+			if hype < 0:
+				hype = 100
+				rank = "A"
+		"A":
+			hype -= A_time*delta
+			if hype < 0:
+				hype = 100
+				rank = "B"
+		"B":
+			hype -= B_time*delta
+			if hype < 0:
+				hype = 100
+				rank = "C"
+		# Note: C is still included in case it is given a drain time of its own later on.
+		"C":
+			hype -= C_time*delta
+			if hype < 0:
+				hype = 0
+		"F":
+			hype = 0
+		_:
+			rank = "C"
+	
+	rank_label.text = rank
+	hype_bar.value = hype
+
+
+# Increases the hype amount and increases the rank if it must
+# This funciton can be called globally using the scene manager
+# by typing `Scenemanager.hype_meter.increase_hype(amount)`
+func increase_hype(amount : float):
+	hype += amount
+	while hype > 100:
+		hype -= 100
+		match rank:
+			"P":
+				hype = 100
+				break
+			"S":
+				rank = "P"
+			"A":
+				rank = "S"
+			"B":
+				rank = "A"
+			"C":
+				rank = "B"
+			_:
+				rank = "C"
+
+
+
+# Feel free to remove this, it's just a temporary thing until actual hype increases are implemented.
+func _on_temp_increase_hype_btn_pressed():
+	Scenemanager.hype_meter.increase_hype(25)

--- a/UIs/Main/hype.gd
+++ b/UIs/Main/hype.gd
@@ -25,6 +25,7 @@ var C_time : float
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
+	# Sets the amount each rank should drain in a second.
 	P_time = 100/P_drain
 	S_time = 100/S_drain
 	A_time = 100/A_drain
@@ -33,8 +34,8 @@ func _ready():
 	Scenemanager.hype_meter = self
 
 
-# Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta):
+	# Using the switch statement, determine how fast the hype should be draining
 	match rank:
 		"P":
 			hype -= P_time*delta
@@ -73,7 +74,7 @@ func _process(delta):
 # Increases the hype amount and increases the rank if it must
 # This funciton can be called globally using the scene manager
 # by typing `Scenemanager.hype_meter.increase_hype(amount)`
-func _increase_hype(amount : float):
+func _increase_hype(amount : float) -> void:
 	hype += amount
 	while hype > 100:
 		hype -= 100

--- a/UIs/Main/hype.gd
+++ b/UIs/Main/hype.gd
@@ -11,26 +11,26 @@ var rank : String = "C"
 
 # Variables containing the time in seconds that each rank will take to fully drain
 # C is not included since it doesn't drain
-var P_drain : float = 2
-var S_drain : float = 4
-var A_drain : float = 5
-var B_drain : float = 6
+var _p_drain : float = 2
+var _s_drain : float = 4
+var _a_drain : float = 5
+var _b_drain : float = 6
 
 # Variables containing the amount that must be removed from the hype every second
-var P_time : float
-var S_time : float
-var A_time : float
-var B_time : float
-var C_time : float
+var _p_time : float
+var _s_time : float
+var _a_time : float
+var _b_time : float
+var _c_time : float
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	# Sets the amount each rank should drain in a second.
-	P_time = 100/P_drain
-	S_time = 100/S_drain
-	A_time = 100/A_drain
-	B_time = 100/B_drain
-	C_time = 0
+	_p_time = 100/_p_drain
+	_s_time = 100/_s_drain
+	_a_time = 100/_a_drain
+	_b_time = 100/_b_drain
+	_c_time = 0
 	Scenemanager.hype_meter = self
 
 
@@ -38,28 +38,28 @@ func _process(delta):
 	# Using the switch statement, determine how fast the hype should be draining
 	match rank:
 		"P":
-			hype -= P_time*delta
+			hype -= _p_time*delta
 			if hype < 0:
 				hype = 100
 				rank = "S"
 		"S":
-			hype -= S_time*delta
+			hype -= _s_time*delta
 			if hype < 0:
 				hype = 100
 				rank = "A"
 		"A":
-			hype -= A_time*delta
+			hype -= _a_time*delta
 			if hype < 0:
 				hype = 100
 				rank = "B"
 		"B":
-			hype -= B_time*delta
+			hype -= _b_time*delta
 			if hype < 0:
 				hype = 100
 				rank = "C"
 		# Note: C is still included in case it is given a drain time of its own later on.
 		"C":
-			hype -= C_time*delta
+			hype -= _c_time*delta
 			if hype < 0:
 				hype = 0
 		"F":

--- a/UIs/Main/hype.tscn
+++ b/UIs/Main/hype.tscn
@@ -1,0 +1,31 @@
+[gd_scene load_steps=2 format=3 uid="uid://dkxtndrdftqva"]
+
+[ext_resource type="Script" path="res://UIs/Main/hype.gd" id="1_ybp5d"]
+
+[node name="Hype" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_ybp5d")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 0
+offset_right = 131.0
+offset_bottom = 54.0
+
+[node name="HypeLabel" type="RichTextLabel" parent="VBoxContainer"]
+layout_mode = 2
+text = "S"
+fit_content = true
+
+[node name="HypeBar" type="ProgressBar" parent="VBoxContainer"]
+layout_mode = 2
+
+[node name="temp_increase_hype_btn" type="Button" parent="VBoxContainer"]
+layout_mode = 2
+text = "more hype!!!"
+
+[connection signal="pressed" from="VBoxContainer/temp_increase_hype_btn" to="." method="_on_temp_increase_hype_btn_pressed"]

--- a/UIs/Main/interface.gd
+++ b/UIs/Main/interface.gd
@@ -2,6 +2,9 @@ extends Control
 
 @export var player_hold : CharacterBody2D
 @onready var health_bar : ProgressBar = $CanvasLayer/VBoxContainer/PlayerHealth
+@onready var left_ammo : RichTextLabel = $CanvasLayer/VBoxContainer/LeftHandAmmo
+@onready var right_ammo : RichTextLabel = $CanvasLayer/VBoxContainer/RightHandAmmo
+@onready var overheat_bar : ProgressBar = $CanvasLayer/VBoxContainer/OverheatBar
 
 
 # Called when the node enters the scene tree for the first time.
@@ -11,5 +14,8 @@ func _ready():
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta):
-	pass
-#	health_bar.value = player_hold.health
+	left_ammo.text = "Left gun ammo: " + str(player_hold.firing_controller._ammo_types[0].ammo)
+	right_ammo.text = "Right gun ammo: " + str(player_hold.firing_controller._ammo_types[1].ammo)
+	overheat_bar.value = player_hold.firing_controller._overheat
+	
+

--- a/UIs/Main/interface.gd
+++ b/UIs/Main/interface.gd
@@ -1,0 +1,15 @@
+extends Control
+
+@export var player_hold : CharacterBody2D
+@onready var health_bar : ProgressBar = $CanvasLayer/VBoxContainer/PlayerHealth
+
+
+# Called when the node enters the scene tree for the first time.
+func _ready():
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	pass
+#	health_bar.value = player_hold.health

--- a/UIs/Main/interface.gd
+++ b/UIs/Main/interface.gd
@@ -1,6 +1,8 @@
 extends Control
 
+# player_hold is a variable containing the player
 @export var player_hold : CharacterBody2D
+# health_bar, left_ammo, right_ammo and overheat_bar all contain the children of this node.
 @onready var health_bar : ProgressBar = $CanvasLayer/VBoxContainer/PlayerHealth
 @onready var left_ammo : RichTextLabel = $CanvasLayer/VBoxContainer/LeftHandAmmo
 @onready var right_ammo : RichTextLabel = $CanvasLayer/VBoxContainer/RightHandAmmo
@@ -12,7 +14,7 @@ func _ready():
 	pass # Replace with function body.
 
 
-# Called every frame. 'delta' is the elapsed time since the previous frame.
+# Set the text of each ammo to their gun, set the overheat bar value.
 func _process(delta):
 	left_ammo.text = "Left gun ammo: " + str(player_hold.firing_controller._ammo_types[0].ammo)
 	right_ammo.text = "Right gun ammo: " + str(player_hold.firing_controller._ammo_types[1].ammo)

--- a/UIs/Main/main_ui.tscn
+++ b/UIs/Main/main_ui.tscn
@@ -1,0 +1,56 @@
+[gd_scene load_steps=3 format=3 uid="uid://ydh7h6mcksme"]
+
+[ext_resource type="Script" path="res://UIs/Main/interface.gd" id="1_rveds"]
+[ext_resource type="PackedScene" uid="uid://dkxtndrdftqva" path="res://UIs/Main/hype.tscn" id="2_xammy"]
+
+[node name="MainUI" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_rveds")
+
+[node name="CanvasLayer" type="CanvasLayer" parent="."]
+
+[node name="VBoxContainer" type="VBoxContainer" parent="CanvasLayer"]
+offset_right = 248.0
+offset_bottom = 296.0
+
+[node name="LeftHandAmmo" type="RichTextLabel" parent="CanvasLayer/VBoxContainer"]
+layout_mode = 2
+text = "Left gun ammo: UNAVAILABLE"
+fit_content = true
+
+[node name="RightHandAmmo" type="RichTextLabel" parent="CanvasLayer/VBoxContainer"]
+layout_mode = 2
+text = "Right gun ammo: UNAVAILABLE"
+fit_content = true
+
+[node name="PlayerHealthLabel" type="RichTextLabel" parent="CanvasLayer/VBoxContainer"]
+layout_mode = 2
+text = "Hit points remaining:"
+fit_content = true
+
+[node name="PlayerHealth" type="ProgressBar" parent="CanvasLayer/VBoxContainer"]
+layout_mode = 2
+
+[node name="OverheatLabel" type="RichTextLabel" parent="CanvasLayer/VBoxContainer"]
+layout_mode = 2
+text = "Overheat:"
+fit_content = true
+
+[node name="OverheatBar" type="ProgressBar" parent="CanvasLayer/VBoxContainer"]
+layout_mode = 2
+
+[node name="Hype" parent="CanvasLayer/VBoxContainer" instance=ExtResource("2_xammy")]
+layout_mode = 2
+size_flags_vertical = 3
+size_flags_stretch_ratio = 4.0
+
+[node name="Hype Boost" type="RichTextLabel" parent="CanvasLayer/VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+text = "Selected Hype Boost: N/A"
+fit_content = true

--- a/UIs/Main/main_ui.tscn
+++ b/UIs/Main/main_ui.tscn
@@ -43,6 +43,9 @@ fit_content = true
 
 [node name="OverheatBar" type="ProgressBar" parent="CanvasLayer/VBoxContainer"]
 layout_mode = 2
+size_flags_vertical = 3
+max_value = 8.0
+show_percentage = false
 
 [node name="Hype" parent="CanvasLayer/VBoxContainer" instance=ExtResource("2_xammy")]
 layout_mode = 2

--- a/project.godot
+++ b/project.godot
@@ -22,6 +22,10 @@ UiManager="*res://Globals/ui_manager.gd"
 Logger="*res://Globals/logger.gd"
 Console="*res://UIs/Console/Console.tscn"
 
+[display]
+
+window/size/mode=3
+
 [dotnet]
 
 project/assembly_name="Shotgun Hands"
@@ -69,11 +73,6 @@ fire_reload={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":82,"key_label":0,"unicode":114,"echo":false,"script":null)
 ]
 }
-fire_melee={
-"deadzone": 0.5,
-"events": [null, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":70,"key_label":0,"unicode":102,"echo":false,"script":null)
-]
-}
 toggle_pause={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194305,"key_label":0,"unicode":0,"echo":false,"script":null)
@@ -82,6 +81,11 @@ toggle_pause={
 _dev_console_toggle={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":96,"key_label":0,"unicode":167,"echo":false,"script":null)
+]
+}
+fire_melee={
+"deadzone": 0.5,
+"events": [null, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":70,"key_label":0,"unicode":102,"echo":false,"script":null)
 ]
 }
 


### PR DESCRIPTION
Changes made:
 - Added hype meter as described in the design document
 - Included a temporary button to increase the hype
 - Fixed the control_labels UI so that is always in the same place on screen

 - created main_ui.tscn scene
 - added placeholder labels for ammo, hit points, overheat and hype boost
 - added the hype meter to this UI
 - reverted previous changes to the control_labels.tscn to avoid interference (see previous commit)

 - Added comments to the Hype meter code
 - Added comments to the UI code
 - Cleaned up code to be more in line with style guide.
Notes:
 - Currently reworking overheat in a branch that was duplicated from this one
 - There is a button that increases hype, which can be deleted if you want.
     - It is a placeholder